### PR TITLE
Return "unknown" if show version info is disabled in Grafana

### DIFF
--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -121,7 +121,7 @@ class GrafanaApi:
     def version(self):
         if not self._grafana_info:
             self._grafana_info = self.health.check()
-        version = self._grafana_info["version"]
+        version = self._grafana_info.get("version", "unknown")
         logger.info(f"Inquired Grafana version: {version}")
         return version
 

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -121,7 +121,7 @@ class GrafanaApi:
     def version(self):
         if not self._grafana_info:
             self._grafana_info = self.health.check()
-        version = self._grafana_info.get("version", "unknown")
+        version = self._grafana_info.get("version", None)
         logger.info(f"Inquired Grafana version: {version}")
         return version
 


### PR DESCRIPTION
## Description
We disabled displaying the version info because of ridiculous security Resasons. 

## Checklist

- [ x ] The patch has appropriate test coverage
- [ x ] The patch follows the style guidelines of this project
- [ x ] The patch has appropriate comments, particularly in hard-to-understand areas
- [ x ] The documentation was updated corresponding to the patch
- [ x ] I have performed a self-review of this patch
