### PR TITLE
Improve Grafana version parsing for patch releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # CHANGELOG
 
 ## unreleased
+- Improve Grafana version parsing for patch releases like `11.3.0-75420.patch2-75797`
+  Thanks, @Zhuse.
 
 
 ## 4.1.0 (2024-04-14)

--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -122,6 +122,8 @@ class GrafanaApi:
         if not self._grafana_info:
             self._grafana_info = self.health.check()
         version = self._grafana_info.get("version", None)
+        if version:
+            version = str(version).rsplit("-")[0]
         logger.info(f"Inquired Grafana version: {version}")
         return version
 

--- a/test/test_grafana_client.py
+++ b/test/test_grafana_client.py
@@ -154,11 +154,22 @@ class TestGrafanaClient(unittest.TestCase):
         self.assertRaises(niquests.exceptions.ConnectionError, lambda: grafana.connect())
 
     @patch("grafana_client.client.GrafanaClient.__getattr__")
-    def test_grafana_client_version(self, mock_get):
+    def test_grafana_client_version_basic(self, mock_get):
         mock_get.return_value = Mock()
         mock_get.return_value.return_value = {"commit": "14e988bd22", "database": "ok", "version": "9.0.1"}
         grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="3000")
         self.assertEqual(grafana.version, "9.0.1")
+
+    @patch("grafana_client.client.GrafanaClient.__getattr__")
+    def test_grafana_client_version_patch(self, mock_get):
+        mock_get.return_value = Mock()
+        mock_get.return_value.return_value = {
+            "commit": "14e988bd22",
+            "database": "ok",
+            "version": "11.3.0-75420.patch2-75797",
+        }
+        grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="3000")
+        self.assertEqual(grafana.version, "11.3.0")
 
     def test_grafana_client_non_json_response(self):
         grafana = GrafanaApi.from_url("https://example.org/")


### PR DESCRIPTION
## About
@Zhuse reported at GH-182 that the library did not parse version numbers like `11.3.0-75420.patch2-75797` well.
