### PR TITLE
allow setting the session pool size in niquests

### DIFF
--- a/grafana_client/api.py
+++ b/grafana_client/api.py
@@ -8,7 +8,7 @@ import niquests
 import niquests.auth
 from urllib3.exceptions import InsecureRequestWarning
 
-from .client import DEFAULT_TIMEOUT, AsyncGrafanaClient, GrafanaClient
+from .client import DEFAULT_SESSION_POOL_SIZE, DEFAULT_TIMEOUT, AsyncGrafanaClient, GrafanaClient
 from .elements import (
     Admin,
     Alerting,
@@ -72,6 +72,7 @@ class GrafanaApi:
         timeout=DEFAULT_TIMEOUT,
         user_agent: str = None,
         organization_id: int = None,
+        session_pool_size=DEFAULT_SESSION_POOL_SIZE,
     ):
         self.client = GrafanaClient(
             auth,
@@ -83,6 +84,7 @@ class GrafanaApi:
             timeout=timeout,
             user_agent=user_agent,
             organization_id=organization_id,
+            session_pool_size=session_pool_size,
         )
         self.url = None
         self.admin = Admin(self.client)

--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -88,6 +88,7 @@ class GrafanaClient:
         timeout=DEFAULT_TIMEOUT,
         user_agent: str = None,
         organization_id: int = None,
+        session_pool_size=DEFAULT_SESSION_POOL_SIZE,
     ):
         self.auth = auth
         self.verify = verify
@@ -96,6 +97,7 @@ class GrafanaClient:
         self.url_port = port
         self.url_path_prefix = url_path_prefix
         self.url_protocol = protocol
+        self.session_pool_size = session_pool_size
 
         def construct_api_url():
             params = {
@@ -118,7 +120,7 @@ class GrafanaClient:
 
         self.user_agent = user_agent or f"{__appname__}/{__version__}"
 
-        self.s = niquests.Session()
+        self.s = niquests.Session(pool_maxsize=session_pool_size)
         self.s.headers["User-Agent"] = self.user_agent
 
         self.organization_id = organization_id
@@ -230,6 +232,7 @@ class AsyncGrafanaClient(GrafanaClient):
         timeout=DEFAULT_TIMEOUT,
         user_agent: str = None,
         organization_id: int = None,
+        session_pool_size=DEFAULT_SESSION_POOL_SIZE,
     ):
         super().__init__(
             auth,
@@ -241,8 +244,9 @@ class AsyncGrafanaClient(GrafanaClient):
             timeout=timeout,
             user_agent=user_agent,
             organization_id=organization_id,
+            session_pool_size=session_pool_size,
         )
-        self.s = niquests.AsyncSession()
+        self.s = niquests.AsyncSession(pool_maxsize=session_pool_size)
         self.s.headers.setdefault("Connection", "keep-alive")
 
     def __getattr__(self, item):

--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -5,6 +5,7 @@ import niquests.auth
 from niquests import HTTPError, Timeout
 
 DEFAULT_TIMEOUT: float = 5.0
+DEFAULT_SESSION_POOL_SIZE: int = 10
 
 
 class GrafanaException(Exception):


### PR DESCRIPTION
## Description
adds ability to set the session pool size in niquests when needed:

```
grafana = GrafanaApi.from_url(
    url=GRAFANA_URL, credential=TokenAuth(token=GRAFANA_API_TOKEN)
)
grafana.client.timeout = 60
grafana.client.session_pool_size = 32
```


## Checklist

- [ ] The patch has appropriate test coverage
- [ ] The patch follows the style guidelines of this project
- [ ] The patch has appropriate comments, particularly in hard-to-understand areas
- [ ] The documentation was updated corresponding to the patch
- [ ] I have performed a self-review of this patch
