### PR TITLE
CI: Fix permissions for GHA release job to designate a release on GitHub

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ concurrency:
 
 jobs:
   release:
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem
```
error: while submitting {"tag_name":"4.2.0","name":"4.2.0","body":"4.2.0","draft":false,"prerelease":false,"generate_release_notes":false}: invalid response body: {"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release","status":"403"}
```

See: https://github.com/grafana-toolbox/grafana-client/actions/runs/11406586752/job/31740673737

## Solution
-- https://stackoverflow.com/a/70448851
