### PR TITLE
CI: Verify support on Python 3.13

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         python-version: [
-          '3.7', '3.12',
+          '3.7', '3.13',
           'pypy-3.7', 'pypy-3.10',
         ]
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## unreleased
+- CI: Verified support on Python 3.13
 
 ## 4.2.0 (2024-10-18)
 - Allowed setting the session pool size in `niquests`. Thanks, @sjoeboo.

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ classifiers =
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
     Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
     Topic :: Communications


### PR DESCRIPTION
## About
[Python 3.13.0](https://www.python.org/downloads/release/python-3130/) has been released on Oct. 7, 2024. This PR intends to add CI verification.

## References
- https://github.com/crate/crate-python/pull/653
