### PR TITLE
fix: fix JSONDEcodeError exception

### DIFF
--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -1,8 +1,8 @@
-from requests.exceptions import JSONDecodeError
-
 import niquests
 import niquests.auth
 from niquests import HTTPError, Timeout
+
+from requests.exceptions import JSONDecodeError
 
 DEFAULT_TIMEOUT: float = 5.0
 DEFAULT_SESSION_POOL_SIZE: int = 10

--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -1,4 +1,4 @@
-from json import JSONDecodeError
+from requests.exceptions import JSONDecodeError
 
 import niquests
 import niquests.auth

--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -1,7 +1,6 @@
 import niquests
 import niquests.auth
 from niquests import HTTPError, Timeout
-
 from requests.exceptions import JSONDecodeError
 
 DEFAULT_TIMEOUT: float = 5.0


### PR DESCRIPTION
## Description
When trying to delete a folder, the exception raised is not `json.JSONDEcodeError` but `requests.exceptions.JSONDECodeError`.

```
JSONDecodeError                           Traceback (most recent call last)
File ~/.local/lib/python3.11/site-packages/requests/models.py:974, in Response.json(self, **kwargs)
    973 try:
--> 974     return complexjson.loads(self.text, **kwargs)
    975 except JSONDecodeError as e:
    976     # Catch JSON-related errors and raise as requests.JSONDecodeError
    977     # This aliases json.JSONDecodeError and simplejson.JSONDecodeError

File /usr/local/lib/python3.11/json/__init__.py:346, in loads(s, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
    343 if (cls is None and object_hook is None and
    344         parse_int is None and parse_float is None and
    345         parse_constant is None and object_pairs_hook is None and not kw):
--> 346     return _default_decoder.decode(s)
    347 if cls is None:

File /usr/local/lib/python3.11/json/decoder.py:337, in JSONDecoder.decode(self, s, _w)
    333 """Return the Python representation of ``s`` (a ``str`` instance
    334 containing a JSON document).
    335 
    336 """
--> 337 obj, end = self.raw_decode(s, idx=_w(s, 0).end())
    338 end = _w(s, end).end()

File /usr/local/lib/python3.11/json/decoder.py:355, in JSONDecoder.raw_decode(self, s, idx)
    354 except StopIteration as err:
--> 355     raise JSONDecodeError("Expecting value", s, err.value) from None
    356 return obj, end

JSONDecodeError: Expecting value: line 1 column 1 (char 0)

During handling of the above exception, another exception occurred:

JSONDecodeError                           Traceback (most recent call last)
Cell In[97], line 1
----> 1 a = c.DELETE(path)

File ~/.local/lib/python3.11/site-packages/grafana_client/client.py:183, in GrafanaClient.__getattr__.<locals>.__request_runner(url, json, data, headers, accept_empty_json)
    181     return r.text
    182 try:
--> 183     return r.json()
    184 except JSONDecodeError:
    185     if accept_empty_json and r.text == "":

File ~/.local/lib/python3.11/site-packages/requests/models.py:978, in Response.json(self, **kwargs)
    974     return complexjson.loads(self.text, **kwargs)
    975 except JSONDecodeError as e:
    976     # Catch JSON-related errors and raise as requests.JSONDecodeError
    977     # This aliases json.JSONDecodeError and simplejson.JSONDecodeError
--> 978     raise RequestsJSONDecodeError(e.msg, e.doc, e.pos)

JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

## Checklist

- [ x] The patch has appropriate test coverage
- [ x] The patch follows the style guidelines of this project
- [ x] The patch has appropriate comments, particularly in hard-to-understand areas
- [ x] The documentation was updated corresponding to the patch
- [ x] I have performed a self-review of this patch
