### PR TITLE
CI: Use Ubuntu 22.04 to keep supporting Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
+        os: ["ubuntu-22.04"]
         python-version: [
           '3.7', '3.13',
           'pypy-3.9', 'pypy-3.10',


### PR DESCRIPTION
## Problem
```
Error: The version '3.7' with architecture 'x64' was not found for Ubuntu 24.04.
```
https://github.com/grafana-toolbox/grafana-client/actions/runs/12641966506/job/35456851179

## Solution
What the title says.

