### PR TITLE
Smartquery: Fix querying PostgreSQL with Grafana 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## unreleased
 - Chore: Removed nonsense function `update_rule_group_interval`. Thanks, @vbichov.
+- Smartquery: Fixed querying PostgreSQL with Grafana 11. Thanks, @hbaghar.
 
 ## 4.2.3 (2025-01-26)
 - Smartquery: Fix querying Prometheus by adding `hide` parameter.

--- a/grafana_client/knowledge.py
+++ b/grafana_client/knowledge.py
@@ -97,7 +97,7 @@ def datasource_factory(datasource: DatasourceModel) -> DatasourceModel:
         datasource.secureJsonData = {
             "password": "root",
         }
-    elif datasource.type == "postgres":
+    elif datasource.type in ["postgres", "grafana-postgresql-datasource"]:
         datasource.user = "postgres"
         datasource.jsonData = {
             "postgresVersion": 1200,


### PR DESCRIPTION
## About

@hbaghar reported that querying PostgreSQL would no longer work.
- GH-180

This patch attempts to fix it, but it has not been tested.