### PR TITLE
Allow the datasource to be specified with managed alerting

### DIFF
--- a/grafana_client/elements/_async/alerting.py
+++ b/grafana_client/elements/_async/alerting.py
@@ -15,9 +15,10 @@ class Alerting(Base):
         get_alertrule_path = "/ruler/grafana/api/v1/rules/%s/%s" % (folder_name, alertrule_name)
         return await self.client.GET(get_alertrule_path)
 
-    async def get_managedalerts_all(self):
+    async def get_managedalerts_all(self, datasource="grafanacloud-prom"):
         """ """
-        return await self.client.GET("/prometheus/grafanacloud-prom/api/v1/rules")
+        get_managedalerts_path = "/prometheus/%s/api/v1/rules" % datasource
+        return await self.client.GET(get_managedalerts_path)
 
     async def create_alertrule(self, folder_name, alertrule):
         """

--- a/grafana_client/elements/alerting.py
+++ b/grafana_client/elements/alerting.py
@@ -15,9 +15,10 @@ class Alerting(Base):
         get_alertrule_path = "/ruler/grafana/api/v1/rules/%s/%s" % (folder_name, alertrule_name)
         return self.client.GET(get_alertrule_path)
 
-    def get_managedalerts_all(self):
+    def get_managedalerts_all(self, datasource="grafanacloud-prom"):
         """ """
-        return self.client.GET("/prometheus/grafanacloud-prom/api/v1/rules")
+        get_managedalerts_path = "/prometheus/%s/api/v1/rules" % datasource
+        return self.client.GET(get_managedalerts_path)
 
     def create_alertrule(self, folder_name, alertrule):
         """


### PR DESCRIPTION
This change allows you to specify the datasource to check for managed alerts. With Grafana Cloud the default looks to be `grafanacloud-prom`. Whereas, with Grafana OSS its `grafana`.

I tested these changes on the Grafana Cloud and a private installation of Grafana.

## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
