### PR TITLE
fix(async): Fix erroneous code conversion causing `TypeError` at `Datasource.smartquery()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 ## unreleased
+- Async: Fixed code generator for edge cases at "smartquery" interface. Thanks, @JIAQIA.
 
 ## 4.3.2 (2025-03-04)
 - Alerting: Allowed the datasource to be specified with managed alerting. Thanks, @dmyerscough.

--- a/grafana_client/elements/_async/datasource.py
+++ b/grafana_client/elements/_async/datasource.py
@@ -353,9 +353,9 @@ class Datasource(Base):
         # Compute request method, body, and endpoint.
         if "method" in request and isinstance(request["method"], str):
             if request["method"] == "POST":
-                send_request = await self.client.POST
+                send_request = self.client.POST
             else:
-                send_request = await self.client.GET
+                send_request = self.client.GET
 
         logger.info(f"Submitting request: {request}")
 
@@ -378,7 +378,7 @@ class Datasource(Base):
                 database_name=datasource.get("database"),
             )
             request_kwargs = {}
-            send_request = await self.client.GET
+            send_request = self.client.GET
 
         elif datasource_type in ("prometheus", "loki") and Version(await self.api.version) <= VERSION_7:
             if (
@@ -411,7 +411,7 @@ class Datasource(Base):
 
         # Submit query.
         try:
-            return send_request(url, **request_kwargs)
+            return await send_request(url, **request_kwargs)
         except (GrafanaClientError, GrafanaServerError) as ex:
             logger.error(
                 f"Querying data source failed. id={datasource_id}, type={datasource_type}. "

--- a/script/generate_async.py
+++ b/script/generate_async.py
@@ -101,13 +101,14 @@ def process(source: Path, target: Path):
 
         module_dump = re.sub(r"( {4}def )(?!_)", r"    async def ", module_dump)
 
-        module_dump = module_dump.replace("self.client.", "await self.client.")
+        module_dump = re.sub(r"self\.client\.(.+)\(", r"await self.client.\1(", module_dump)
 
         for relative_import in [".base", "..client", "..knowledge", "..model"]:
             module_dump = module_dump.replace(f"from {relative_import}", f"from .{relative_import}")
 
         module_dump = module_dump.replace("self.api.version", "await self.api.version")
-        module_dump = module_dump.replace("= self.", "= await self.")
+        module_dump = re.sub(r"= self\.(.+)\(", r"= await self.\1(", module_dump)
+        module_dump = re.sub(r"send_request\(", r"await send_request(", module_dump)
 
         module_processed.append(module_path)
         target_path = Path(str(module_path).replace(str(source), str(target)))


### PR DESCRIPTION
## About

Kudos to @JIAQIA for submitting this.

> This fixes a TypeError that occurred when trying to await HTTP method references instead of properly calling them. The changes:
>
> 1. Remove incorrect `await` when assigning POST/GET method references
> 2. Add proper `await` when actually making the request
>
> The bug prevented successful POST requests in the async datasource query functionality.

## References
- GH-223
- GH-224
