### PR TITLE
AMG compatibility: Fetch Grafana version from `/api/frontend/settings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # CHANGELOG
 
 ## unreleased
+- AMG compatibility: Fetch Grafana version from `/api/frontend/settings`
+  instead of `/api/health`. Thanks, @squadgazzz.
+  **Breaking change:** This means that authentication is obligatory now, because the
+  new endpoint requires it. Also, `database` status is no longer represented in the
+  new response.
 
 ## 4.3.3 (2025-07-27)
 - Async: Fixed code generator for edge cases at "smartquery" interface. Thanks, @JIAQIA.

--- a/grafana_client/elements/_async/health.py
+++ b/grafana_client/elements/_async/health.py
@@ -8,8 +8,10 @@ class Health(Base):
 
     async def check(self):
         """
+        Return Grafana build information, compatible with Grafana, and Amazon Managed Grafana (AMG).
 
         :return:
         """
-        path = "/health"
-        return await self.client.GET(path)
+        path = "/frontend/settings"
+        response = await self.client.GET(path)
+        return response.get("buildInfo")

--- a/grafana_client/elements/health.py
+++ b/grafana_client/elements/health.py
@@ -8,8 +8,10 @@ class Health(Base):
 
     def check(self):
         """
+        Return Grafana build information, compatible with Grafana, and Amazon Managed Grafana (AMG).
 
         :return:
         """
-        path = "/health"
-        return self.client.GET(path)
+        path = "/frontend/settings"
+        response = self.client.GET(path)
+        return response.get("buildInfo")

--- a/test/elements/test_dashboard.py
+++ b/test/elements/test_dashboard.py
@@ -36,8 +36,8 @@ class DashboardTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_dashboard_by_name_grafana7(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "6f8c1d9fe4", "database": "ok", "version": "7.5.11"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "6f8c1d9fe4", "version": "7.5.11"}},
         )
         m.get(
             "http://localhost/api/dashboards/db/Production Overview",
@@ -64,8 +64,8 @@ class DashboardTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_dashboard_by_name_grafana8(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "8.0.2"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "8.0.2"}},
         )
         with self.assertRaises(DeprecationWarning) as ex:
             self.grafana.dashboard.get_dashboard_by_name("foobar")

--- a/test/elements/test_datasource_base.py
+++ b/test/elements/test_datasource_base.py
@@ -132,8 +132,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_enable_datasource_permissions(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.1"}},
         )
 
         m.post(
@@ -147,8 +147,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_enable_datasource_permissions_grafana1023(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.3"}},
         )
 
         with patch(
@@ -162,8 +162,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_disable_datasource_permissions(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.1"}},
         )
 
         m.post(
@@ -177,8 +177,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_disable_datasource_permissions_grafana1023(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.3"}},
         )
 
         with patch(
@@ -192,8 +192,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_datasource_permissions(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.1"}},
         )
 
         m.get(
@@ -207,8 +207,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_datasource_permissions_grafana1023(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.3"}},
         )
 
         with patch(
@@ -222,8 +222,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_add_datasource_permissions(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.1"}},
         )
 
         m.post(
@@ -237,8 +237,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_add_datasource_permissions_grafana1023(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.3"}},
         )
 
         with patch(
@@ -252,8 +252,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove_datasource_permissions(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.1"}},
         )
 
         m.delete(
@@ -267,8 +267,8 @@ class DatasourceTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove_datasource_permissions_grafana1023(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.3"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.3"}},
         )
 
         with patch(
@@ -395,8 +395,8 @@ class DatasourceTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Prometheus responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "7.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "7.0.1"}},
         )
         m.post(
             "http://localhost/api/ds/query",
@@ -411,8 +411,8 @@ class DatasourceTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Prometheus responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.post(
             "http://localhost/api/ds/query",
@@ -453,8 +453,8 @@ class DatasourceTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Prometheus responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/h8KkCLt7z",
@@ -472,8 +472,8 @@ class DatasourceTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Prometheus responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         datasource = PROMETHEUS_DATASOURCE.copy()
         datasource["access"] = "__UNKNOWN__"

--- a/test/elements/test_datasource_health.py
+++ b/test/elements/test_datasource_health.py
@@ -332,8 +332,8 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Loki responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "7.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "7.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/vCyglaq7z",
@@ -364,8 +364,8 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Loki responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/vCyglaq7z",
@@ -396,8 +396,8 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Loki responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "7.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "7.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/vCyglaq7z",
@@ -428,8 +428,8 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Loki responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/vCyglaq7z",
@@ -565,8 +565,8 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Prometheus responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": grafana_version},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": grafana_version}},
         )
         m.get(
             "http://localhost/api/datasources/uid/h8KkCLt7z",
@@ -599,8 +599,8 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Prometheus responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": grafana_version},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": grafana_version}},
         )
         m.get(
             "http://localhost/api/datasources/uid/h8KkCLt7z",
@@ -633,8 +633,8 @@ class DatasourceHealthCheckTestCase(unittest.TestCase):
         # Mock the version inquiry request, because `smartquery` needs
         # it, as Prometheus responses differ between versions.
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": grafana_version},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": grafana_version}},
         )
         m.get(
             "http://localhost/api/datasources/uid/h8KkCLt7z",
@@ -1161,8 +1161,8 @@ class DatasourceHealthInquiryTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_health_inquiry_native_prometheus_success(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/39mf288en",
@@ -1191,8 +1191,8 @@ class DatasourceHealthInquiryTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_health_inquiry_native_prometheus_failure(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/39mf288en",
@@ -1221,8 +1221,8 @@ class DatasourceHealthInquiryTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_health_inquiry_native_unknown_error_400(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/39mf288en",
@@ -1252,8 +1252,8 @@ class DatasourceHealthInquiryTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_health_inquiry_native_unknown_error_418(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/39mf288en",
@@ -1271,8 +1271,8 @@ class DatasourceHealthInquiryTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_health_inquiry_native_prometheus_error_404(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/h8KkCLt7z",
@@ -1308,8 +1308,8 @@ class DatasourceHealthInquiryTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_health_inquiry_native_prometheus_error_500(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "14e988bd22", "database": "ok", "version": "9.0.1"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "14e988bd22", "version": "9.0.1"}},
         )
         m.get(
             "http://localhost/api/datasources/uid/h8KkCLt7z",

--- a/test/elements/test_health.py
+++ b/test/elements/test_health.py
@@ -12,10 +12,9 @@ class HealthTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_healthcheck(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "6f8c1d9fe4", "database": "ok", "version": "7.5.11"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "6f8c1d9fe4", "version": "7.5.11"}},
         )
 
         result = self.grafana.health.check()
-        self.assertEqual(result["database"], "ok")
-        self.assertEqual(len(result), 3)
+        self.assertEqual(result["version"], "7.5.11")

--- a/test/elements/test_libraryelement.py
+++ b/test/elements/test_libraryelement.py
@@ -589,8 +589,8 @@ class LibraryElementTestCase(unittest.TestCase):
         }
     }
 
-    HealthResponsePre8_2: dict = {"commit": "unknown", "database": "ok", "version": "8.1.8"}
-    HealthResponsePost8_2: dict = {"commit": "unknown-dev", "database": "ok", "version": "10.2.2"}
+    HealthResponsePre8_2: dict = {"buildInfo": {"commit": "unknown", "version": "8.1.8"}}
+    HealthResponsePost8_2: dict = {"buildInfo": {"commit": "unknown-dev", "version": "10.2.2"}}
 
     def setUp(self):
         self.grafana = GrafanaApi(("admin", "admin"), host="localhost", url_path_prefix="", protocol="http")
@@ -598,7 +598,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -611,7 +611,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_grafana_pre_8_2(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.get(
@@ -628,7 +628,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_notfound(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -644,7 +644,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_notfound_grafana_pre_8_2(self, m):
         def custom_matcher(request):
-            if request.path_url == "/api/health":
+            if request.path_url == "/api/frontend/settings":
                 return None
             resp = requests.Response()
             resp.status_code = 404
@@ -653,7 +653,7 @@ class LibraryElementTestCase(unittest.TestCase):
             return resp
 
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.add_matcher(custom_matcher)
@@ -667,7 +667,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_by_name(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -680,7 +680,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_by_name_grafana_pre_8_2(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.get(
@@ -697,7 +697,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_by_name_notfound(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -713,7 +713,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_by_name_notfound_grafana_pre_8_2(self, m):
         def custom_matcher(request):
-            if request.path_url == "/api/health":
+            if request.path_url == "/api/frontend/settings":
                 return None
             resp = requests.Response()
             resp.status_code = 404
@@ -722,7 +722,7 @@ class LibraryElementTestCase(unittest.TestCase):
             return resp
 
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.add_matcher(custom_matcher)
@@ -736,7 +736,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_connections(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -753,7 +753,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_connections_grafana_pre_8_2(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.get(
@@ -770,7 +770,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_connections_notfound(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -786,7 +786,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_connections_notfound_grafana_pre_8_2(self, m):
         def custom_matcher(request):
-            if request.path_url == "/api/health":
+            if request.path_url == "/api/frontend/settings":
                 return None
             resp = requests.Response()
             resp.status_code = 404
@@ -795,7 +795,7 @@ class LibraryElementTestCase(unittest.TestCase):
             return resp
 
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.add_matcher(custom_matcher)
@@ -809,7 +809,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_connections_noconnections(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -824,7 +824,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_get_library_element_connections_noconnections_grafana_pre_8_2(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.get(
@@ -841,7 +841,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create_library_element(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.post(
@@ -864,7 +864,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create_library_element_grafana_pre_8_2(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.post(
@@ -886,7 +886,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_create_library_element_already_exists(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.post(
@@ -907,7 +907,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_update_library_element(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.patch(
@@ -938,7 +938,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_update_library_element_grafana_pre_8_2(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.patch(
@@ -961,7 +961,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_update_library_element_notfound(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.patch(
@@ -983,7 +983,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_delete_library_element_connections(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.delete(
@@ -999,7 +999,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_delete_library_element_noconnections(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.delete(
@@ -1014,7 +1014,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_delete_library_element_notfound(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.delete(
@@ -1030,7 +1030,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_delete_library_element_notfound_grafana_pre_8_2(self, m):
         def custom_matcher(request):
-            if request.path_url == "/api/health":
+            if request.path_url == "/api/frontend/settings":
                 return None
             resp = requests.Response()
             resp.status_code = 404
@@ -1039,7 +1039,7 @@ class LibraryElementTestCase(unittest.TestCase):
             return resp
 
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.add_matcher(custom_matcher)
@@ -1053,7 +1053,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_library_elements(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePost8_2,
         )
         m.get(
@@ -1073,7 +1073,7 @@ class LibraryElementTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_list_library_elements_grafana_pre_8_2(self, m):
         m.get(
-            "http://localhost/api/health",
+            "http://localhost/api/frontend/settings",
             json=LibraryElementTestCase.HealthResponsePre8_2,
         )
         m.get(

--- a/test/elements/test_team.py
+++ b/test/elements/test_team.py
@@ -336,8 +336,8 @@ class TeamsTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove_team_external_group_grafana_1020(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.2.0"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.2.0"}},
         )
 
         m.delete(
@@ -350,8 +350,8 @@ class TeamsTestCase(unittest.TestCase):
     @requests_mock.Mocker()
     def test_remove_team_external_group(self, m):
         m.get(
-            "http://localhost/api/health",
-            json={"commit": "unknown", "database": "ok", "version": "10.1.0"},
+            "http://localhost/api/frontend/settings",
+            json={"buildInfo": {"commit": "unknown", "version": "10.1.0"}},
         )
 
         m.delete(

--- a/test/test_grafana_client.py
+++ b/test/test_grafana_client.py
@@ -23,6 +23,22 @@ class MockResponse:
         return self.json_data
 
 
+frontend_settings_buildinfo_payload = {
+    "buildInfo": {
+        "buildstamp": 1753567501,
+        "commit": "e0ba4b480954f8a33aa2cff3229f6bcc05777bd9",
+        "commitShort": "e0ba4b4809",
+        "edition": "Open Source",
+        "env": "production",
+        "hasUpdate": True,
+        "hideVersion": False,
+        "latestVersion": "12.1.0",
+        "version": "11.6.2",
+        "versionString": "Grafana v11.6.2 (e0ba4b4809)",
+    }
+}
+
+
 class TestGrafanaClient(unittest.TestCase):
     def test_grafana_client_user_agent_default(self):
         grafana = GrafanaApi.from_url()
@@ -142,12 +158,11 @@ class TestGrafanaClient(unittest.TestCase):
 
     @patch("grafana_client.client.GrafanaClient.__getattr__")
     def test_grafana_client_connect_success(self, mock_get):
-        payload = {"commit": "14e988bd22", "database": "ok", "version": "9.0.1"}
         mock_get.return_value = Mock()
-        mock_get.return_value.return_value = payload
+        mock_get.return_value.return_value = frontend_settings_buildinfo_payload
         grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="3000")
-        grafana_info = grafana.connect()
-        self.assertEqual(grafana_info, payload)
+        grafana_build_info = grafana.connect()
+        self.assertEqual(grafana_build_info["version"], "11.6.2")
 
     def test_grafana_client_connect_failure(self):
         grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="32425")
@@ -156,17 +171,17 @@ class TestGrafanaClient(unittest.TestCase):
     @patch("grafana_client.client.GrafanaClient.__getattr__")
     def test_grafana_client_version_basic(self, mock_get):
         mock_get.return_value = Mock()
-        mock_get.return_value.return_value = {"commit": "14e988bd22", "database": "ok", "version": "9.0.1"}
+        mock_get.return_value.return_value = frontend_settings_buildinfo_payload
         grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="3000")
-        self.assertEqual(grafana.version, "9.0.1")
+        self.assertEqual(grafana.version, "11.6.2")
 
     @patch("grafana_client.client.GrafanaClient.__getattr__")
     def test_grafana_client_version_patch(self, mock_get):
         mock_get.return_value = Mock()
         mock_get.return_value.return_value = {
-            "commit": "14e988bd22",
-            "database": "ok",
-            "version": "11.3.0-75420.patch2-75797",
+            "buildInfo": {
+                "version": "11.3.0-75420.patch2-75797",
+            }
         }
         grafana = GrafanaApi(auth=None, host="localhost", url_path_prefix="", protocol="http", port="3000")
         self.assertEqual(grafana.version, "11.3.0")


### PR DESCRIPTION
## Problem

Using the `/api/health` endpoint is problematic, because Amazon Managed Grafana (AMG) doesn't support it.

## Solution

Apply the solution as [suggested](https://github.com/grafana-toolbox/grafana-wtf/pull/144) by @squadgazzz to use the `/api/frontend/settings` endpoint instead -- thanks again!

## References

- GH-216
- https://github.com/grafana-toolbox/grafana-wtf/issues/141
- https://github.com/grafana-toolbox/grafana-snapshots-tool/issues/7
- https://github.com/grafana-toolbox/grafana-wtf/pull/144

/cc @bhks, @philipnrmn, @ImerysOTDataAndArchitecture, @interfan7