### PR TITLE
Alerting Provisioning: Added support for the `name` query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## unreleased
 - Async: Fixed code generator for edge cases at "smartquery" interface. Thanks, @JIAQIA.
+- Alerting Provisioning: Added support for the optional `name` query parameter to the
+  `get_contactpoints` method, for filtering by name. Thanks, @devth.
 
 ## 4.3.2 (2025-03-04)
 - Alerting: Allowed the datasource to be specified with managed alerting. Thanks, @dmyerscough.

--- a/grafana_client/elements/_async/alertingprovisioning.py
+++ b/grafana_client/elements/_async/alertingprovisioning.py
@@ -81,13 +81,16 @@ class AlertingProvisioning(Base):
         delete_alertrule_path = "/v1/provisioning/alert-rules/%s" % alertrule_uid
         return await self.client.DELETE(delete_alertrule_path)
 
-    async def get_contactpoints(self):
+    async def get_contactpoints(self, name=None):
         """
-        Gets all contact points
+        Gets all contact points, optionally filtering by name.
         @return:
         """
-        get_contactpoints_path = "/v1/provisioning/contact-points"
-        return await self.client.GET(get_contactpoints_path)
+        path = "/v1/provisioning/contact-points"
+        params = {}
+        if name:
+            params = {"name": name}
+        return await self.client.GET(path, params=params)
 
     async def create_contactpoint(self, contactpoint, disable_provenance=False):
         """

--- a/grafana_client/elements/alertingprovisioning.py
+++ b/grafana_client/elements/alertingprovisioning.py
@@ -81,13 +81,16 @@ class AlertingProvisioning(Base):
         delete_alertrule_path = "/v1/provisioning/alert-rules/%s" % alertrule_uid
         return self.client.DELETE(delete_alertrule_path)
 
-    def get_contactpoints(self):
+    def get_contactpoints(self, name=None):
         """
-        Gets all contact points
+        Gets all contact points, optionally filtering by name.
         @return:
         """
-        get_contactpoints_path = "/v1/provisioning/contact-points"
-        return self.client.GET(get_contactpoints_path)
+        path = "/v1/provisioning/contact-points"
+        params = {}
+        if name:
+            params = {"name": name}
+        return self.client.GET(path, params=params)
 
     def create_contactpoint(self, contactpoint, disable_provenance=False):
         """


### PR DESCRIPTION
## About
The `get_contactpoints` method receives support for filtering by name, as suggested by @devth. Thanks!
