### PR TITLE
[FIX] CodeRabbit introduced SyntaxWarning

### DIFF
--- a/grafana_client/elements/_async/datasource.py
+++ b/grafana_client/elements/_async/datasource.py
@@ -417,7 +417,7 @@ class Datasource(Base):
                 return await self.query(
                     datasource_id=datasource.get("id"),
                     query=request["expr"],
-                    timestamp=["data"]["to"],
+                    timestamp=request["data"]["to"],
                 )
             else:
                 return await self.query_range(

--- a/grafana_client/elements/datasource.py
+++ b/grafana_client/elements/datasource.py
@@ -411,7 +411,7 @@ class Datasource(Base):
                 return self.query(
                     datasource_id=datasource.get("id"),
                     query=request["expr"],
-                    timestamp=["data"]["to"],
+                    timestamp=request["data"]["to"],
                 )
             else:
                 return self.query_range(


### PR DESCRIPTION
## Description
https://github.com/grafana-toolbox/grafana-client/commit/3447924ecb6ff686016ffea081e27b7a9e47d7c9 introduced a wrong suggestion and introduced a SyntaxWarning when using this project. This patch fixes the syntax to make the behaviour the same as before the change.

```
/code/.venv/lib/python3.13/site-packages/grafana_client/elements/datasource.py:414: SyntaxWarning: list indices must be integers or slices, not str; perhaps you missed a comma?
  timestamp=["data"]["to"],
/code/.venv/lib/python3.13/site-packages/grafana_client/elements/_async/datasource.py:420: SyntaxWarning: list indices must be integers or slices, not str; perhaps you missed a comma?
  timestamp=["data"]["to"],
````

## Checklist

- [x] The patch has appropriate test coverage
- [x] The patch follows the style guidelines of this project
- [x] The patch has appropriate comments, particularly in hard-to-understand areas
- [x] The documentation was updated corresponding to the patch
- [x] I have performed a self-review of this patch
