### PR TITLE
Preserve configured headers for async clients

### DIFF
--- a/grafana_client/client.py
+++ b/grafana_client/client.py
@@ -245,7 +245,10 @@ class AsyncGrafanaClient(GrafanaClient):
             organization_id=organization_id,
             session_pool_size=session_pool_size,
         )
+        headers = self.s.headers.copy()
+        self.s.close()
         self.s = niquests.AsyncSession(pool_maxsize=session_pool_size)
+        self.s.headers.update(headers)
         self.s.headers.setdefault("Connection", "keep-alive")
 
     def __getattr__(self, item):

--- a/test/test_grafana_client.py
+++ b/test/test_grafana_client.py
@@ -8,6 +8,7 @@ import pytest
 
 from grafana_client.api import GrafanaApi
 from grafana_client.client import (
+    AsyncGrafanaClient,
     GrafanaClientError,
     GrafanaServerError,
     GrafanaTimeoutError,
@@ -202,3 +203,17 @@ def test_grafana_client_timeout(docker_grafana):
     with pytest.raises(GrafanaTimeoutError) as excinfo:
         grafana.folder.get_all_folders()
     assert excinfo.match("timed out")
+
+
+class TestAsyncClientHeaders(unittest.TestCase):
+    def test_preserves_organization_and_custom_user_agent(self):
+        client = AsyncGrafanaClient(None, organization_id=42, user_agent="custom-agent")
+        self.assertEqual(client.s.headers["X-Grafana-Org-Id"], "42")
+        self.assertEqual(client.s.headers["User-Agent"], "custom-agent")
+
+    def test_preserves_default_user_agent_without_organization(self):
+        from grafana_client import __appname__, __version__
+
+        client = AsyncGrafanaClient(None)
+        self.assertEqual(client.s.headers["User-Agent"], f"{__appname__}/{__version__}")
+        self.assertNotIn("X-Grafana-Org-Id", client.s.headers)


### PR DESCRIPTION
AsyncGrafanaClient replaces the synchronous session but previously lost configured User-Agent and X-Grafana-Org-Id headers. Copy the existing headers when replacing the session and cover organization and custom header behavior.